### PR TITLE
Localization, Slug alert & fixed input-append style

### DIFF
--- a/Resources/public/less/main.less
+++ b/Resources/public/less/main.less
@@ -268,3 +268,28 @@ fieldset[data-admin=form-collapsible-fieldset] {
     }
   }
 }
+
+
+/* Input groups with icon/text append */
+.input-append {
+    display: table !important;
+    width: 100% !important;
+
+    input,
+    .add-on {
+        -webkit-box-sizing: border-box !important;
+        -moz-box-sizing: border-box !important;
+        box-sizing: border-box !important;
+        display: table-cell !important;
+        height: 30px;
+    }
+    input {
+        width: 100% !important;
+    }
+    .add-on {
+        border-left: none !important;
+        padding-left: 8px !important;
+        padding-right: 8px !important;
+        width: 1% !important;
+    }
+}

--- a/Resources/translations/SnowcapAdminBundle.en.yml
+++ b/Resources/translations/SnowcapAdminBundle.en.yml
@@ -180,3 +180,7 @@ error:
         notfound:
             title: Ow! Unable to find this document ...
             message: The document you tried to reach doesn't exist.<br/>If you came here through a link, it's more likely that the document has been deleted.
+
+slug_alert:
+    title: ATTENTION
+    message: If you change the slug, you can break links on other pages!

--- a/Resources/translations/SnowcapAdminBundle.fr.yml
+++ b/Resources/translations/SnowcapAdminBundle.fr.yml
@@ -180,3 +180,7 @@ error:
         notfound:
             title: Oh! Ce document est introuvable ...
             message: Le document que vous avez demandé n'existe pas.<br/>Si vous êtes arrivés ici via un lien, il est fort probable que le document a été supprimé.
+
+slug_alert:
+    title: ATTENTION
+    message: Si vous modifiez le slug, vous pouvez casser des liens sur d'autres pages !

--- a/Resources/views/Form/form_admin_layout.html.twig
+++ b/Resources/views/Form/form_admin_layout.html.twig
@@ -80,13 +80,13 @@
 
 {# slug widget #}
 {% block snowcap_admin_slug_widget %}
-    {% set attr = attr|merge({'data-admin': 'form-slugger', 'data-target': target, 'data-modal': '#modal-' ~ id }) %}
+    {% set attr = attr|merge({ 'data-admin': 'form-slugger', 'data-target': target, 'data-modal': '#modal-' ~ id }) %}
     <div class="input-append">
         {{ block('form_widget') }}
         <span class="add-on"><a href="#locked"><i class="icon-pencil icon"></i></a></span>
     </div>
     {% from 'SnowcapBootstrapBundle::macros.html.twig' import modal %}
-    {{ modal('modal-' ~ id, 'ATTENTION', 'If you change the slug, you can break links on other pages') }}
+    {{ modal('modal-' ~ id, 'slug_alert.title'|trans({}, 'SnowcapAdminBundle'), 'slug_alert.message'|trans({}, 'SnowcapAdminBundle')) }}
 {% endblock snowcap_admin_slug_widget %}
 
 {# markdown widget #}

--- a/Resources/views/Form/form_localize.html.twig
+++ b/Resources/views/Form/form_localize.html.twig
@@ -1,0 +1,35 @@
+{% set fields = fields|default(null) %}
+
+{% set prefix = random() %}
+<ul class="nav nav-tabs translation-tabs">
+    {% for locale in _locales %}
+        {% block tab_item %}
+            <li class="{% if loop.first %}active{% endif %}"><a href="#{{ prefix }}_{{ locale }}" data-toggle="tab">{{ locale|language|capitalize }}</a></li>
+        {% endblock %}
+    {% endfor %}
+</ul>
+
+<div class="tab-content translation-content">
+    {% for locale in _locales %}
+        <div class="tab-pane{% if loop.first %} active{% endif %}" id="{{ prefix }}_{{ locale }}" data-locale="{{ locale|language|capitalize }}">
+
+            {% set translation = form.translations[locale] %}
+            {% block tab_fields %}
+                {% if fields is empty %}
+                    {% for field in translation %}
+                        {{ form_row(field) }}
+                    {% endfor %}
+                {% else %}
+                    {% for field in fields %}
+                        {{ form_row(translation[field]) }}
+                    {% endfor %}
+                {% endif %}
+            {% endblock %}
+        </div>
+    {% endfor %}
+    {% if form.translations.vars.errors is not empty %}
+        <div class="error">
+            {{ form_errors(form.translations) }}
+        </div>
+    {% endif %}
+</div>


### PR DESCRIPTION
- Added form_localize layout: To use in association with SnowcapI18nBundle; in order to generate nice forms for translatable entities
- Fixed style for input-append form widgets
- SlugType: Fixed not translated alert
